### PR TITLE
chore: Simplify GitHub Pages workflow and clean up package.json

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,10 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and Export
-        run: |
-          npm run build
-          npm run export
+      - name: Build
+        run: npm run build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "GITHUB_PAGES=true next build",
     "start": "next start",
-    "lint": "next lint",
-    "export": "next export"
+    "lint": "next lint"
   },
   "dependencies": {
     "jspdf": "^3.0.1",


### PR DESCRIPTION
Removed the export step from the GitHub Pages workflow to streamline the deployment process. Updated package.json to remove the export script, aligning with the current deployment strategy focused solely on building the application.